### PR TITLE
Fix session creation date

### DIFF
--- a/app/lib/models/sessions.py
+++ b/app/lib/models/sessions.py
@@ -12,7 +12,7 @@ class SessionModel(db.Model):
     active = db.Column(db.Boolean, default=False, index=True, nullable=True)
     notifications_enabled = db.Column(db.Boolean, default=False, index=True, nullable=True)
     terminate_at = db.Column(db.DateTime, nullable=True)
-    created_at = db.Column(db.DateTime, nullable=True, default=datetime.datetime.now())
+    created_at = db.Column(db.DateTime, nullable=True, default=datetime.datetime.now)
 
 
 class SessionNotificationModel(db.Model):


### PR DESCRIPTION
The `datetime.now()` function gets called only once and every session will have the same creation date until the server is restarted.

SQLAlchemy can handle function references and now calls `datetime.now()` every time a new session is created.